### PR TITLE
feat: update quick restart

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ Extension changelog
 <h3 id="186">
 Version 1.8.6
 </h3>
-Updated quick restart algorithm due to UI changes, added tab mute while restart to prevent sound
+Updated quick restart algorithm due to UI changes, added tab mute when restarting to prevent sound
 <hr>
 <h3 id="1854">
 Version 1.8.5.4 (hotfix)

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@ Neko's Seterra Features Wizard
 Extension changelog
 </h3>
 <hr>
+<h3 id="186">
+Version 1.8.6
+</h3>
+Updated quick restart algorithm due to UI changes, added tab mute while restart to prevent sound
+<hr>
 <h3 id="1854">
 Version 1.8.5.4 (hotfix)
 </h3>

--- a/chromium/NekoSeterraChromium.js
+++ b/chromium/NekoSeterraChromium.js
@@ -216,7 +216,6 @@ function spaceKeyDownHandler(event) {
       // prevent "game end" sound
       const correctAnswersPercentage = document.querySelector(".game-header_left__Psq9Q label:nth-of-type(2)");
       const unmuteAfterMs = (correctAnswersPercentage && correctAnswersPercentage.textContent === "100%") ? UNMUTE_AFTER_MS_LONG : UNMUTE_AFTER_MS_SHORT;
-      console.log(unmuteAfterMs, correctAnswersPercentage)
       tryStartGame(unmuteAfterMs);
   }
 }

--- a/chromium/NekoSeterraChromium.js
+++ b/chromium/NekoSeterraChromium.js
@@ -1,3 +1,8 @@
+// Things you might want change
+// 0 = sound every time you restart, 1000 = echo, 1500 = slight echo, ~2700 = no echo 
+const UNMUTE_AFTER_MS_LONG = 1000;
+const UNMUTE_AFTER_MS_SHORT = 300;
+
 ///  Form creation for user settings.
 function createForm() {
     if (!document.getElementById("NekoAddon")) {
@@ -199,16 +204,58 @@ function noLeftSpace(bool) {
 }
 
 ///  Map reset function.
+let unmuteTimeoutId
 function spaceKeyDownHandler(event) {
-    if (event.code == "Space") {
-        event.preventDefault();
-        if (document.querySelectorAll('button.button_button__aR6_e.button_variantPrimary__u3WzI')[0]) {
-            document.querySelectorAll('button.button_button__aR6_e.button_variantPrimary__u3WzI')[0].click();
+  if (event.code == "Space") {
+      event.preventDefault();
+      clearTimeout(unmuteTimeoutId);
+      const quitButton = document.querySelector(".game-header_quitGameButton__zTYUz");
+      if (quitButton) {
+        quitButton.click();
+      }
+      // prevent "game end" sound
+      const correctAnswersPercentage = document.querySelector(".game-header_left__Psq9Q label:nth-of-type(2)");
+      const unmuteAfterMs = (correctAnswersPercentage && correctAnswersPercentage.textContent === "100%") ? UNMUTE_AFTER_MS_LONG : UNMUTE_AFTER_MS_SHORT;
+      console.log(unmuteAfterMs, correctAnswersPercentage)
+      tryStartGame(unmuteAfterMs);
+  }
+}
+const OVERLAY_CLASS = "game-overlay_wrapper__egT_7";
+function tryStartGame(unmuteAfterMs) {
+  const overlay = document.querySelector(".".concat(OVERLAY_CLASS));
+  if (overlay) {
+    // already available, no need to wait
+    handleStartGame(overlay);
+  } else {
+    chrome.runtime.sendMessage({ action: "muteTab" });
+    // wait for start button to appear
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node.classList.contains(OVERLAY_CLASS)) {
+            handleStartGame(node, observer, unmuteAfterMs);
+          }
         }
-        else {
-            document.querySelectorAll("button.button_button__aR6_e.button_variantSecondaryInverted__6G2ex.button_sizeSmall__MB_qj")[1].click();
-        }
+      }
+    });
+    const gameWrapper = document.querySelector(".game-area_gameWrapper__QWih6");
+    // const startButton = document.querySelector('[data-qa="start-quiz-button"]');
+    observer.observe(gameWrapper, { subtree: true, childList: true });
+  }
+}
+function handleStartGame(overlay, observer, unmuteAfterMs) {
+  clearTimeout(unmuteTimeoutId);
+  overlay.style.display = "none";
+  const startButton = document.querySelector('[data-qa="start-quiz-button"]');
+  if (startButton) {
+    startButton.click();
+    if (observer) {
+      observer.disconnect();
     }
+    unmuteTimeoutId = setTimeout(() => {
+      chrome.runtime.sendMessage({ action: "unmuteTab" });
+    }, unmuteAfterMs)
+  }
 }
 ///  Map reset check.
 function mapReset(bool) {

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -1,0 +1,7 @@
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message.action === "muteTab") {
+    chrome.tabs.update(sender.tab.id, { muted: true });
+  } else if (message.action === "unmuteTab") {
+    chrome.tabs.update(sender.tab.id, { muted: false });
+  }
+});

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -2,12 +2,16 @@
   "manifest_version": 3,
   "name": "Neko's Settera Features Wizard",
   "description": "Adds Neko's Settera addons to all https://www.geoguessr.com/vgp/ pages.",
-  "version": "1.8.5.4",
+  "version": "1.8.6",
   "permissions": [
-    "storage"
+    "storage",
+    "tabs"
   ],
   "icons": {
     "512": "icons/seterra.png"
+  },
+  "background": {
+    "service_worker": "background.js"
   },
   "content_scripts": [
     {

--- a/firefox/NekoSeterraFirefox.js
+++ b/firefox/NekoSeterraFirefox.js
@@ -1,3 +1,8 @@
+// Things you might want change
+// 0 = sound every time you restart, 1000 = echo, 1500 = slight echo, ~2700 = no echo 
+const UNMUTE_AFTER_MS_LONG = 1000;
+const UNMUTE_AFTER_MS_SHORT = 300;
+
 ///  Form creation for user settings.
 function createForm() {
     if (!document.getElementById("NekoAddon")) {
@@ -198,17 +203,58 @@ function noLeftSpace(bool) {
 
 }
 
-///  Map reset function.
+let unmuteTimeoutId
 function spaceKeyDownHandler(event) {
-    if (event.code == "Space") {
-        event.preventDefault();
-        if (document.querySelectorAll('button.button_button__aR6_e.button_variantPrimary__u3WzI')[0]) {
-            document.querySelectorAll('button.button_button__aR6_e.button_variantPrimary__u3WzI')[0].click();
+  if (event.code == "Space") {
+      event.preventDefault();
+      clearTimeout(unmuteTimeoutId);
+      const quitButton = document.querySelector(".game-header_quitGameButton__zTYUz");
+      if (quitButton) {
+        quitButton.click();
+      }
+      // prevent "game end" sound
+      const correctAnswersPercentage = document.querySelector(".game-header_left__Psq9Q label:nth-of-type(2)");
+      const unmuteAfterMs = (correctAnswersPercentage && correctAnswersPercentage.textContent === "100%") ? UNMUTE_AFTER_MS_LONG : UNMUTE_AFTER_MS_SHORT;
+      console.log(unmuteAfterMs, correctAnswersPercentage)
+      tryStartGame(unmuteAfterMs);
+  }
+}
+const OVERLAY_CLASS = "game-overlay_wrapper__egT_7";
+function tryStartGame(unmuteAfterMs) {
+  const overlay = document.querySelector(".".concat(OVERLAY_CLASS));
+  if (overlay) {
+    // already available, no need to wait
+    handleStartGame(overlay);
+  } else {
+    chrome.runtime.sendMessage({ action: "muteTab" });
+    // wait for start button to appear
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node.classList.contains(OVERLAY_CLASS)) {
+            handleStartGame(node, observer, unmuteAfterMs);
+          }
         }
-        else {
-            document.querySelectorAll("button.button_button__aR6_e.button_variantSecondaryInverted__6G2ex.button_sizeSmall__MB_qj")[1].click();
-        }
+      }
+    });
+    const gameWrapper = document.querySelector(".game-area_gameWrapper__QWih6");
+    // const startButton = document.querySelector('[data-qa="start-quiz-button"]');
+    observer.observe(gameWrapper, { subtree: true, childList: true });
+  }
+}
+function handleStartGame(overlay, observer, unmuteAfterMs) {
+  clearTimeout(unmuteTimeoutId);
+  overlay.style.display = "none";
+  const startButton = document.querySelector('[data-qa="start-quiz-button"]');
+  if (startButton) {
+    startButton.click();
+    if (observer) {
+      observer.disconnect();
     }
+    unmuteTimeoutId = setTimeout(() => {
+      chrome.runtime.sendMessage({ action: "unmuteTab" });
+    }, unmuteAfterMs)
+  }
 }
 ///  Map reset check.
 function mapReset(bool) {

--- a/firefox/NekoSeterraFirefox.js
+++ b/firefox/NekoSeterraFirefox.js
@@ -203,6 +203,7 @@ function noLeftSpace(bool) {
 
 }
 
+///  Map reset function.
 let unmuteTimeoutId
 function spaceKeyDownHandler(event) {
   if (event.code == "Space") {
@@ -215,7 +216,6 @@ function spaceKeyDownHandler(event) {
       // prevent "game end" sound
       const correctAnswersPercentage = document.querySelector(".game-header_left__Psq9Q label:nth-of-type(2)");
       const unmuteAfterMs = (correctAnswersPercentage && correctAnswersPercentage.textContent === "100%") ? UNMUTE_AFTER_MS_LONG : UNMUTE_AFTER_MS_SHORT;
-      console.log(unmuteAfterMs, correctAnswersPercentage)
       tryStartGame(unmuteAfterMs);
   }
 }

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -1,0 +1,7 @@
+browser.runtime.onMessage.addListener((message, sender) => {
+  if (message.action === "muteTab") {
+    browser.tabs.update(sender.tab.id, { muted: true });
+  } else if (message.action === "unmuteTab") {
+    browser.tabs.update(sender.tab.id, { muted: false });
+  }
+});

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -2,8 +2,8 @@
   "description": "Adds Neko's Settera addons to all https://www.geoguessr.com/vgp/ pages.",
   "manifest_version": 2,
   "name": "Neko's Settera Features Wizard",
-  "version": "1.8.5.5",
-  "permissions": [ "storage", "http://*/*", "https://*/*" ],
+  "version": "1.8.6",
+  "permissions": [ "storage", "tabs", "http://*/*", "https://*/*" ],
   "homepage_url": "https://github.com/NekoXIII/SeterraAddon/tree/main",
   "icons": { "512": "icons/seterra.png" },
   "content_scripts": [
@@ -12,6 +12,9 @@
       "js": [ "NekoSeterraFirefox.js" ]
     }
   ],
+  "background": {
+    "scripts": ["background.js"]
+  },
   "browser_specific_settings": {
     "gecko": {
       "id": "nekoseterra@uwu.com"


### PR DESCRIPTION
Geoguessr removed the restart button. Now you have to click "Quit" (cross icon) > "Start quiz", which made quick restart not working

When you click the newly added quit button, page produces a sound as if you ended the game (if you have 100%, it plays winning sound, which is long; else it plays a short sound). Muting `<audio>` HTML element with relevant `src` attribute doesn't work because the sounds are played purely from JavaScript, without creating an element (as far as I understand). That's why I mute the tab from a background script, but it also mutes click sounds. I allowed some from the 100% winning sound echo to play as a compromise, but this solution is not perfect. It's probably better to just use a macro

Updated version to 1.8.6 in manifest, added a changelog entry